### PR TITLE
:fire: drop --output-mets from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+
+Removed:
+
+  * --output-mets CLI option
+
 ## TODO
 
 ## [1.2.0] - 2018-05-25

--- a/cli.md
+++ b/cli.md
@@ -45,10 +45,6 @@ Minimum Log level. One of `OFF`, `ERROR`, `WARN`, `INFO` (default), `DEBUG`, `TR
 Actual mechanism for filtering log messages must not be implemented by
 processors.
 
-### `-o, --output-mets METS_OUT`
-
-File path where processor MUST write resulting METS to. If not set, output METS is expected to be in the file `mets.xml` in the working directory.
-
 ### `-J, --dump-json`
 
 Instead of processing METS, output the [ocrd-tool](ocrd_tool) description for
@@ -74,7 +70,6 @@ This is how the CLI provided by the MP should work:
 $> ocrd-kraken-binarize \
     --mets "file:///path/to/file/mets.xml" \
     --working-dir "file:///path/to/workingDir/" \
-    --output-mets /path/to/workingDir/metsOutput.xml \
     --parameters "file:///path/to/file/parameters.json" \
     --group-id OCR-D-IMG_0001,OCR-D-IMG_0002 \
     --group-id OCR-D-IMG_0003 \
@@ -88,7 +83,6 @@ And this is how it will be called with the `ocrd` CLI:
 $> ocrd process \
     -m "file:///path/to/file/mets.xml" \
     -w "file:///path/to/workingDir/" \
-    -o /path/to/workingDir/metsOutput.xml \
     -p "file:///path/to/file/parameters.json" \
     -g OCR-D-IMG_0001,OCR-D-IMG_0002 \
     -g OCR-D-IMG_0003 \
@@ -102,7 +96,7 @@ $> ocrd process \
 
 Binarize images from METS file with GROUPIDs id0001, id0002 and id0003.
 
-### Input METS file
+### METS input
 
 ```xml
 <mets:mets>
@@ -136,9 +130,9 @@ Binarize images from METS file with GROUPIDs id0001, id0002 and id0003.
 }
 ```
 
-### Output METS file
+### METS output
 
-This is the METS file as it is returned by the MP CLI:
+This is the METS file after being run through the MP CLI:
 
 ```xml
 <mets:mets>


### PR DESCRIPTION
This is a breaking change -> major version increase.