### PR TITLE
OCRD-ZIP clarify that relative paths are prefered over file URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changed:
   * OCRD-ZIP: bagit profile: Contact info
   * OCRD-ZIP: `Ocrd-Mets` and `mets:FLocat` URI/paths must be relative to `/data`
   * OCRD-ZIP: Filenames MUST be relative to mets.xml
+  * METS: Filenames MAY/SHOULD be relative to mets.xml
 
 ## [2.6.1] - 2018-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changed:
   * OCRD-ZIP: bagit profile: Add empty list requirement for `Tag-Manifest-Required`, `Tag-Files-Required`
   * OCRD-ZIP: bagit profile: Contact info
   * OCRD-ZIP: `Ocrd-Mets` and `mets:FLocat` URI/paths must be relative to `/data`
+  * OCRD-ZIP: Filenames MUST be relative to mets.xml
 
 ## [2.6.1] - 2018-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-  * OCRD-ZIP bagit profile: Add empty list requirement for `Tag-Manifest-Required`, `Tag-Files-Required`
-  * OCRD-ZIP bagit profile: Contact info
+Changed:
+
+  * OCRD-ZIP: bagit profile: Add empty list requirement for `Tag-Manifest-Required`, `Tag-Files-Required`
+  * OCRD-ZIP: bagit profile: Contact info
+  * OCRD-ZIP: `Ocrd-Mets` and `mets:FLocat` URI/paths must be relative to `/data`
 
 ## [2.6.1] - 2018-11-09
 

--- a/mets.md
+++ b/mets.md
@@ -162,19 +162,28 @@ The PAGE XML root element `<pc:PcGts>` MUST have exactly one `<pc:Page>`.
 
 Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
 
-## Always use URL everywhere
+## Always use URL or relative filenames
 
-Always use URL. If it's a local file, prefix absolute path with `file://`.
+Always use URL, except for files located in the directory or any subdirectories of the METS file.
 
 ### Example
 
-```xml
-<mets:fileGrp USE="OCR-D-SEG-BLOCK">
-    <mets:file ID="OCR-D-SEG-BLOCK_0001" MIMETYPE="application/vnd.prima.page+xml">
-        <mets:FLocat xmlns:xlink="http://www.w3.org/1999/xlink" LOCTYPE="URL" xlink:href="file:///path/to/workingDir/segmentation/block/page_0001.xml" />
-    </mets:file>
-</mets:fileGrp>
+```sh
+/tmp/foo/ws1
+├── mets.xml
+├── foo.tif
+└── foo.xml
 ```
+
+Valid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
+* `foo.xml`
+* `foo.tif`
+* `file://foo.tif`
+
+Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
+* `/tmp/foo/ws1/foo.xml` (absolute path)
+* `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
+* `file:///foo.tif` (relative path written as absolute path)
 
 ## If in PAGE then in METS
 

--- a/ocrd_zip.md
+++ b/ocrd_zip.md
@@ -49,7 +49,7 @@ the full definition](#appendix-a)):
   * [`Ocrd-Identifier`](#ocrd-identifier): A globally unique identifier for this bag
   * [`Ocrd-Base-Version-Checksum`](#ocrd-base-version-checksum): Checksum of the version this bag is based on
 * `bag-info.txt` MAY additionally contain these tags:
-  * [`Ocrd-Mets`](#ocrd-mets): Alternative path to the mets.xml file, relative to `/data`, if its path IS NOT `mets.xml`
+  * [`Ocrd-Mets`]: Alternative path to the mets.xml file, relative to `/data`, if its path IS NOT `mets.xml`
   * [`Ocrd-Manifestation-Depth`](#ocrd-manifestation-depth): Whether all URL are dereferenced as files or only some
 
 ### `BagIt-Profile-Identifier`
@@ -151,17 +151,15 @@ To pack a workspace to OCRD-ZIP:
   * Replace the URL of `f` with the path relative to `/data` (SHOULD be `<USE>/<ID>`) in
     * all `mets:FLocat` of the METS
     * all other files in the workspace, esp. PAGE-XML
-* Write out the changed METS to `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets))
+* Write out the changed METS to `TMP/data/mets.xml`
 * Package `TMP` as a BagIt bag
 
 ### Unpacking OCRD-ZIP to a workspace
 
 * Unzip OCRD-ZIP `z` to a folder `TMP`
-* Let `M` be `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets))
-* Foreach file `f` in `M`:
-  * Strip `file://` from the beginning of the `xlink:href` of `f`
-  * If it is not a file path (begins with `http://` or `https://`):
-    continue
+* If the value `M` of [`Ocrd-Mets`] is different from `mets.xml`:
+  * Rename `TMP/data/mets.xml` to `TMP/data/` + `M`
+* Move `TMP/data` to an appropriate location to use as a workspace
 
 ## Appendix A - BagIt profile definition
 
@@ -209,3 +207,5 @@ Accept-BagIt-Version:
 Proposed media type of OCRD-ZIP: `application/vnd.ocrd+zip`
 
 Proposed extension: `.ocrd.zip`
+
+[`Ocrd-Mets`]: #ocrd-mets

--- a/ocrd_zip.md
+++ b/ocrd_zip.md
@@ -140,17 +140,18 @@ To pack a workspace to OCRD-ZIP:
   * Replace the URL of `f` with the path relative to `/data` (SHOULD be `<USE>/<ID>`) in
     * all `mets:FLocat` of the METS
     * all other files in the workspace, esp. PAGE-XML
-* Write out the changed METS to `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets)
+* Write out the changed METS to `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets))
 * Package `TMP` as a BagIt bag
 
 ### Unpacking OCRD-ZIP to a workspace
 
 * Unzip OCRD-ZIP `z` to a folder `TMP`
-* Foreach file `f` in `TMP/data/mets.xml`:
+* Let `M` be `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets))
+* Foreach file `f` in `M`:
   * If it is not a `file://`-URL and not a file path,
     continue
   * Replace the URL of `f` with `<ABSPATH>`, where `<ABSPATH>` is the absolute path to `f`, in
-    * `TMP/data/mets.xml`
+    * `M`
     * all files within `TMP`, esp. PAGE-XML
 
 ## Appendix A - BagIt profile definition

--- a/ocrd_zip.md
+++ b/ocrd_zip.md
@@ -49,7 +49,7 @@ the full definition](#appendix-a)):
   * [`Ocrd-Identifier`](#ocrd-identifier): A globally unique identifier for this bag
   * [`Ocrd-Base-Version-Checksum`](#ocrd-base-version-checksum): Checksum of the version this bag is based on
 * `bag-info.txt` MAY additionally contain these tags:
-  * [`Ocrd-Mets`](#ocrd-mets): Alternative path to the mets.xml file if its path IS NOT `/data/mets.xml`
+  * [`Ocrd-Mets`](#ocrd-mets): Alternative path to the mets.xml file, relative to `/data`, if its path IS NOT `mets.xml`
   * [`Ocrd-Manifestation-Depth`](#ocrd-manifestation-depth): Whether all URL are dereferenced as files or only some
 
 ### `BagIt-Profile-Identifier`
@@ -58,9 +58,12 @@ The `BagIt-Profile-Identifier` must be the string `https://ocr-d.github.io/bagit
 
 ### `Ocrd-Mets`
 
-By default, the METS file should be at `data/mets.xml`. If this file has
-another name, it must be listed here and implementations MUST check for
-`Ocrd-Mets` before assuming `data/mets.xml`.
+`Ocrd-Mets` can be provided to declare that the METS file will not be the
+standard `mets.xml` but another path relative to `/data/`.
+
+Implementations MUST check for the `Ocrd-Mets` tag: If it has a value, look for the
+METS file at that location, relative to `/data`. Otherwise, assume the default
+`mets.xml`.
 
 ### `Ocrd-Manifestation-Depth`
 
@@ -127,25 +130,26 @@ be referenced in a `mets:file/mets:Flocat` in the `mets.xml`.
 To pack a workspace to OCRD-ZIP:
 
 * Create a temporary folder `TMP`
-* Copy mets.xml to `TMP/data/mets.xml`
-* Foreach `mets:file` `f` in `TMP/data/mets.xml`:
-  * If it is not a `file://`-URL
-    * If `Ocrd-Manifestation-Depth` is `partial`
+* Foreach `mets:file` `f` in the source METS:
+  * If it is not a `file://`-URL and not a file path
+    * If `Ocrd-Manifestation-Depth` is `partial`,
       continue
   * Download/Copy the file to a location within `TMP/data`. The structure SHOULD be `<USE>/<ID>` where
     * `<USE>` is the `USE` attribute of the parent `mets:fileGrp`
     * `<ID>` is the `ID` attribute of the `mets:file`
-  * Replace the URL of `f` with `file:///data/<USE>/<ID>` in
-    * all `mets:FLocat` of `TMP/data/mets.xml`
+  * Replace the URL of `f` with the path relative to `/data` (SHOULD be `<USE>/<ID>`) in
+    * all `mets:FLocat` of the METS
     * all other files in the workspace, esp. PAGE-XML
+* Write out the changed METS to `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets)
 * Package `TMP` as a BagIt bag
 
 ### Unpacking OCRD-ZIP to a workspace
 
 * Unzip OCRD-ZIP `z` to a folder `TMP`
 * Foreach file `f` in `TMP/data/mets.xml`:
-  * If it is not a `file://`-URL, continue
-  * Replace the URL of `f` with `file://<ABSPATH>`, where `<ABSPATH>` is the absolute path to `f`, in
+  * If it is not a `file://`-URL and not a file path,
+    continue
+  * Replace the URL of `f` with `<ABSPATH>`, where `<ABSPATH>` is the absolute path to `f`, in
     * `TMP/data/mets.xml`
     * all files within `TMP`, esp. PAGE-XML
 

--- a/ocrd_zip.md
+++ b/ocrd_zip.md
@@ -102,21 +102,31 @@ of the BagIt spec, the entries MUST be sorted.
 
 **NOTE:** These checksums can be generated with `find data -type f | sort -sf |xargs sha512sum > manifest-sha512.txt`.
 
-### `file://`-URLs must be relative
+### File names must be relative to METS
 
-All resources referenced in the METS with a `file://`-URL (and consequently all
-those referenced in other files within the workspace -- see rule "When in PAGE
-then in METS") must be referenced by `file://`-URL that is absolute with root
-being the root location of the workspace, i.e. they MUST begin with
-`file:///data`
+Within an OCRD-ZIP, all local file resources referenced in the METS (and
+consequently all those referenced in other files within the workspace -- see
+rule ["If in PAGE then in METS"](mets#if-in-page-then-in-mets) must be
+relative to the [location of the METS file](#ocrd-mets).
 
-Right:
-* `file:///data/foo.xml`
-* `file:///data/foo.tif`
-* `http:///data/server/foo.tif`
+#### Example
 
-Wrong:
-* `file:///absolute/path/somewhere/foo.tif`
+```sh
+/tmp/foo/ws1/data
+├── mets.xml
+├── foo.tif
+└── foo.xml
+```
+
+Valid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/data/mets.xml`:
+* `foo.xml`
+* `foo.tif`
+* `file://foo.tif`
+
+Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/data/mets.xml`:
+* `/tmp/foo/ws1/data/foo.xml` (absolute path)
+* `file:///tmp/foo/ws1/data/foo.tif` (file URL scheme with absolute path)
+* `file:///foo.tif` (relative path written as absolute path)
 
 ### When in data then in METS
 
@@ -131,7 +141,8 @@ To pack a workspace to OCRD-ZIP:
 
 * Create a temporary folder `TMP`
 * Foreach `mets:file` `f` in the source METS:
-  * If it is not a `file://`-URL and not a file path
+  * Strip `file://` from the beginning of the `xlink:href` of `f`
+  * If it is not a file path (begins with `http://` or `https://`):
     * If `Ocrd-Manifestation-Depth` is `partial`,
       continue
   * Download/Copy the file to a location within `TMP/data`. The structure SHOULD be `<USE>/<ID>` where
@@ -148,11 +159,9 @@ To pack a workspace to OCRD-ZIP:
 * Unzip OCRD-ZIP `z` to a folder `TMP`
 * Let `M` be `TMP/data/mets.xml` (or another location in `TMP/data/`, specified by [`Ocrd-Mets`](#ocrd-mets))
 * Foreach file `f` in `M`:
-  * If it is not a `file://`-URL and not a file path,
+  * Strip `file://` from the beginning of the `xlink:href` of `f`
+  * If it is not a file path (begins with `http://` or `https://`):
     continue
-  * Replace the URL of `f` with `<ABSPATH>`, where `<ABSPATH>` is the absolute path to `f`, in
-    * `M`
-    * all files within `TMP`, esp. PAGE-XML
 
 ## Appendix A - BagIt profile definition
 


### PR DESCRIPTION
It's more consistent to have the restrictions on the payload be always relative to the `/data` directory in a bag.

It is also closer to reality and easy to detect whether a string is a relative path or a URL. It allows working with standard tools (without removing `file://` prefixes, prefixing `/data` or any using absolute paths).

The implementation does it like that, this just up the definitions.