### PR TITLE
additional consistency level "lax"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Added:
+
+  * Consistency check level 'lax'
+
 Fixed:
 
   * Example in ocrd_tool.md is from ocrd_kraken, not ocrd_tesserocr

--- a/page.md
+++ b/page.md
@@ -118,10 +118,17 @@ results](#multiple-textequivs) are attached.
 
 ### Consistency strictness
 
-A consistency checker must support three levels of strictness:
+A consistency checker must support four levels of strictness:
 
 #### `strict`
+
 If any of the assertions fail for a PAGE document, an exception
+should be raised and the document no further processed
+
+#### `lax`
+
+If any of the assertions fail for a PAGE document, another comparison
+disregarding all whitespace shall be made. If this still fails, an exception
 should be raised and the document no further processed
 
 #### `fix`


### PR DESCRIPTION
Otherwise, punctuation encoded as `Word` are a nightmare of false positives and/or byzantine concatenation rules.