### PR TITLE
explicate missing long-standing conventions...

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -1,13 +1,16 @@
 # Command Line Interface (CLI)
 
+All tools provided by MP must be standalone executables, installable into `$PATH`.
+
+Those tools intended for run-time data processing (but not necessarily tools for training or deployment) are called **processors**.
+Processors must adhere to the following uniform interface, including mandatory and optional parameters (i.e. no more or fewer are permissible).
+
 **NOTE:** Command line options cannot be repeated. Parameters marked
-**MULTI-VALUE** specify multiple values, provide a single string with
+**MULTI-VALUE** specify multiple values, formatted as a single string with
 comma-separated items (e.g. `-I group1,group2,group3` instead of `-I group1 -I
 group2 -I group3`).
 
 ## CLI executable name
-
-All CLI provided by MP must be standalone executables, installable into `$PATH`.
 
 Every CLI executable's name must begin with `ocrd-`.
 
@@ -21,7 +24,9 @@ Examples:
 
 **MULTI-VALUE**
 
-File group(s) used as input.
+[METS](mets) file group(s) used as input.
+
+Input file groups must not be modified.
 
 ## Optional parameters
 
@@ -29,13 +34,13 @@ File group(s) used as input.
 
 **MULTI-VALUE**
 
-File group(s) used as output.
+[METS](mets) file group(s) used as output.
 
-Omit to resort to default output file groups of the processor or for processors that do not produce output files.
+Omit to resort to default output file groups of the processor, or for processors that inherently do not produce output files.
 
 ### `-m, --mets METS_IN`
 
-Input METS URL. Default: `mets.xml`
+Input [METS](mets) URL. Default: `mets.xml`
 
 ### `-w, --working-dir DIR`
 
@@ -51,11 +56,15 @@ to files representing a page. Effectively, only those files in the [input file
 group](#-i---input-file-grp-grp) that are referenced in these
 `mets:div[@TYPE="page"]` will be processed.
 
+Omit to process all pages.
+
 ### `-p, --parameter PARAM_JSON`
 
-URL of parameter file in JSON format. If that file is not readable and
-`PARAM_JSON` begins with `{` (opening brace), try to parse `PARAM_JSON` as
-JSON. If that also fails, throw an exception.
+URL of parameter file in [JSON format](https://json.org/) corresponding to the `parameters` section of the processor's [ocrd-tool metadata](ocrd_tool).
+If that file is not readable and `PARAM_JSON` begins with `{` (opening brace), try to parse `PARAM_JSON` as JSON.
+If that also fails, throw an exception.
+
+Omit to use default parameters only, or for processors without any parameters.
 
 ### `-l, --log-level LOGLEVEL`
 


### PR DESCRIPTION
- introduce term _processor_ properly
- clarify mandatory/optional w.r.t. conforming
- add cross-references to METS and ocrd-tool specs
- add statement about strictly functional / non-destructive interface
- clarify that no `-g` means all pages
- clarify that no `-p` means default/no parameters