### PR TITLE
CLI: Introduce parameter presets, #158

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -134,13 +134,13 @@ other implementation-specific means of logging configuration. For example, with
 Instead of processing METS, output the [ocrd-tool](ocrd_tool) description for
 this executable, in particular its parameters.
 
-### `-C, --preset PRESET_NAME`
+### `-C, --show-asset FILENAME`
 
-Print the contents of preset `PRESET_NAME`. Look up the resp. JSON file according to [file parameter lookup rules](ocrd_tool#file-parameter)
+Print the contents of processor asset `FILENAME`. Look up the resp. absolute filename according to the [file parameter lookup rules](ocrd_tool#file-parameter).
 
-### `-L, --presets`
+### `-L, --list-assets`
 
-List the names of [presets](#presets).
+List the names of [processor-assets](#processor-assets) in all of the paths defined by.the [file parameter lookup rules](ocrd_tool#file-parameter), one name per line.
 
 ### `-h, --help`
 
@@ -168,14 +168,22 @@ The log messages must have the format `TIME LEVEL LOGGERNAME - MESSAGE\n`, where
 * `MESSAGE` is the message to log, should not contain new lines.
 * `\n` is ASCII char `0x0a` (newline)
 
-## Presets
+## Processor assets
 
-Processors can be bundled with pre-defined sets of [parameter JSON
-files](#-p--parameter-param_json), called *presets*. A preset can be used in
-calling a processor by using the *preset name* instead of a JSON
-string/filename. Preset names can be listed by calling a processor with the
-[`--presets`](#-L---presets) option. Presets must be resolved with the same
-[rules for looking up file parameter values](ocrd_tool#file-parameters).
+Parameters that reference files can be resolved from relative to absolute
+filename by following the [conventions laid out in the `ocrd_tool`
+spec](ocrd_tool#file-parameters). These files, either bundled by the processor
+developer or put in place by the user, are called *processor assets*. The
+*processor assets* of a processor can be listed with the `-L/--list-assets`
+option and individual *processor assets* can be retrieved with the
+`-C/--show-asset` option. Since *processor assets* use the same mechanism
+as file parameters, they can be used
+
+  * as the argument to the `-p/--parameter` option, and
+  * as the value of a file parameter
+
+and the processor must resolve them to absolute paths [according to the rules
+for file parameters](ocrd_tool#file-parameters).
 
 ## URL/file convention
 

--- a/cli.md
+++ b/cli.md
@@ -179,8 +179,8 @@ option and individual *processor assets* can be retrieved with the
 `-C/--show-asset` option. Since *processor assets* use the same mechanism
 as file parameters, they can be used
 
-  * as the argument to the `-p/--parameter` option, and
-  * as the value of a file parameter
+  * as the argument to the `-p/--parameter` option (i.e. a **preset** file), and
+  * as the value of a file-type parameter (e.g. a **model** file)
 
 and the processor must resolve them to absolute paths [according to the rules
 for file parameters](ocrd_tool#file-parameters).

--- a/cli.md
+++ b/cli.md
@@ -102,6 +102,14 @@ other implementation-specific means of logging configuration. For example, with
 Instead of processing METS, output the [ocrd-tool](ocrd_tool) description for
 this executable, in particular its parameters.
 
+### `-C, --preset PRESET_NAME`
+
+Print the contents of preset `PRESENT_NAME`. Look up the resp. JSON file according to [preset lookup path](#presets)
+
+### `-L, --presets`
+
+List the names of [presets](#presets).
+
 ### `-h, --help`
 
 Print a concise description of the tool, the command line options and
@@ -127,6 +135,23 @@ The log messages must have the format `TIME LEVEL LOGGERNAME - MESSAGE\n`, where
 * `LOGGERNAME` is the name of the logging component, such as the class name. Segments of `LOGGERNAME` should be separated by dot `.`, e.g. `ocrd.fancy_tool.analyze`
 * `MESSAGE` is the message to log, should not contain new lines.
 * `\n` is ASCII char `0x0a` (newline)
+
+## Presets
+
+Processors can be bundled with pre-defined sets of [parameter JSON
+files](#-p---parameter-param_json), called *presets*. A preset can be used in
+calling a processor by using the *preset name* instead of a JSON
+string/filename. Preset names can be listed by calling a processor with the
+[`--presets`](#-L---presets). In addittion to the presets bundled with a processor `ocrd-xyz`, presets
+must also be looked iertain file system locations. The lookup should be in the following priority:
+
+* `$PWD/.ocrd-xyz/<preset name>.json`
+* `$VIRTUAL_ENV/share/ocrd-xyz/<preset name>.json`
+* `$HOME/.local/share/ocrd-xyz/<preset name>.json`
+* `/etc/ocrd-xyz/<preset name>.json`
+* `/usr/local/share/ocrd-xyz/<preset name>.json`
+* `/usr/share/ocrd-xyz/<preset name>.json`
+* (bundled preset named `<preset name`)
 
 ## URL/file convention
 

--- a/cli.md
+++ b/cli.md
@@ -136,7 +136,7 @@ this executable, in particular its parameters.
 
 ### `-C, --preset PRESET_NAME`
 
-Print the contents of preset `PRESENT_NAME`. Look up the resp. JSON file according to [preset lookup path](#presets)
+Print the contents of preset `PRESET_NAME`. Look up the resp. JSON file according to [file parameter lookup rules](ocrd_tool#file-parameter)
 
 ### `-L, --presets`
 
@@ -171,19 +171,11 @@ The log messages must have the format `TIME LEVEL LOGGERNAME - MESSAGE\n`, where
 ## Presets
 
 Processors can be bundled with pre-defined sets of [parameter JSON
-files](#-p---parameter-param_json), called *presets*. A preset can be used in
+files](#-p--parameter-param_json), called *presets*. A preset can be used in
 calling a processor by using the *preset name* instead of a JSON
 string/filename. Preset names can be listed by calling a processor with the
-[`--presets`](#-L---presets). In addittion to the presets bundled with a processor `ocrd-xyz`, presets
-must also be looked iertain file system locations. The lookup should be in the following priority:
-
-* `$PWD/.ocrd-xyz/<preset name>.json`
-* `$VIRTUAL_ENV/share/ocrd-xyz/<preset name>.json`
-* `$HOME/.local/share/ocrd-xyz/<preset name>.json`
-* `/etc/ocrd-xyz/<preset name>.json`
-* `/usr/local/share/ocrd-xyz/<preset name>.json`
-* `/usr/share/ocrd-xyz/<preset name>.json`
-* (bundled preset named `<preset name`)
+[`--presets`](#-L---presets) option. Presets must be resolved with the same
+[rules for looking up file parameter values](ocrd_tool#file-parameters).
 
 ## URL/file convention
 

--- a/cli.md
+++ b/cli.md
@@ -134,13 +134,13 @@ other implementation-specific means of logging configuration. For example, with
 Instead of processing METS, output the [ocrd-tool](ocrd_tool) description for
 this executable, in particular its parameters.
 
-### `-C, --show-asset FILENAME`
+### `-C, --show-resource FILENAME`
 
-Print the contents of processor asset `FILENAME`. Look up the resp. absolute filename according to the [file parameter lookup rules](ocrd_tool#file-parameter).
+Print the contents of processor resource `FILENAME`. Look up the resp. absolute filename according to the [file parameter lookup rules](ocrd_tool#file-parameter).
 
-### `-L, --list-assets`
+### `-L, --list-resources`
 
-List the names of [processor-assets](#processor-assets) in all of the paths defined by.the [file parameter lookup rules](ocrd_tool#file-parameter), one name per line.
+List the names of [processor resources](#processor-resources) in all of the paths defined by.the [file parameter lookup rules](ocrd_tool#file-parameter), one name per line.
 
 ### `-h, --help`
 
@@ -168,15 +168,15 @@ The log messages must have the format `TIME LEVEL LOGGERNAME - MESSAGE\n`, where
 * `MESSAGE` is the message to log, should not contain new lines.
 * `\n` is ASCII char `0x0a` (newline)
 
-## Processor assets
+## Processor resources
 
 Parameters that reference files can be resolved from relative to absolute
 filename by following the [conventions laid out in the `ocrd_tool`
 spec](ocrd_tool#file-parameters). These files, either bundled by the processor
-developer or put in place by the user, are called *processor assets*. The
-*processor assets* of a processor can be listed with the `-L/--list-assets`
-option and individual *processor assets* can be retrieved with the
-`-C/--show-asset` option. Since *processor assets* use the same mechanism
+developer or put in place by the user, are called *processor resources*. The
+*processor resources* of a processor can be listed with the `-L/--list-resources`
+option and individual *processor resources* can be retrieved with the
+`-C/--show-resource` option. Since *processor resources* use the same mechanism
 as file parameters, they can be used
 
   * as the argument to the `-p/--parameter` option (i.e. a **preset** file), and


### PR DESCRIPTION
The intention here is to simplify re-using parameter settings. Processors can bundle parameter setting presets, e.g. using a specific model or a specific combination of values. Users can store such presets at certain locations in the file system. A preset name can be used instead of a JSON string or filename for the `-p`/`--parameter` CLI option.

This is a first draft, bundled presets should probably described in `ocrd-tool.json` and lookup path simplified, etc.