### PR TITLE
Alternative image same folder

### DIFF
--- a/mets.md
+++ b/mets.md
@@ -91,7 +91,7 @@ with the type of manipulation (`BIN-KRAKEN`).
 `<mets:fileGrp USE="OCR-D-SEG-WORD">`       | Word segmentation
 `<mets:fileGrp USE="OCR-D-SEG-GLYPH">`      | Glyph segmentation
 `<mets:fileGrp USE="OCR-D-OCR-TESS">`       | [Tesseract OCR](https://github.com/OCR-D/ocrd_tesserocr)
-`<mets:fileGrp USE="OCR-D-OCR-ANY">`        | [AnyOCR](https://github.com/OCR-D/ocrd_anybaseocr)
+`<mets:fileGrp USE="OCR-D-OCR-OCRO">`        | [Ocropus OCR](https://github.com/OCR-D/ocrd_cis)
 `<mets:fileGrp USE="OCR-D-COR-CIS">`        | [CIS post-correction](https://github.com/cisocrgroup/ocrd_cis)
 `<mets:fileGrp USE="OCR-D-COR-ASV">`        | [ASV post-correction](https://github.com/ASVLeipzig/cor-asv-ann)
 `<mets:fileGrp USE="OCR-D-GT-SEG-REGION">`   | Region segmentation ground truth

--- a/mets.md
+++ b/mets.md
@@ -54,10 +54,6 @@ For this purpose, the METS file MUST contain a `mods:identifier` that must conta
 * `url`
 
 
-## File Group 
-
-All `mets:file` inside a `mets:fileGrp` MUST have the same `MIMETYPE`.
-
 ## File Group USE syntax
 
 All `mets:fileGrp` MUST have a **unique** `USE` attribute that hints at the provenance of the files.

--- a/mets.md
+++ b/mets.md
@@ -106,10 +106,7 @@ The `ID` MUST be unique inside the METS file.
 
 ```
 FILEID := ID + "_" + [0-9]{4}
-ID := "OCR-D-" + WORKFLOW_STEP + ("-" + FEATURE)* + ("-" + PROCESSOR)?
-FEATURE := ("BIN" | "CROP" | "DESKEW" | DESPECK" | "DEWARP" )
-WORKFLOW_STEP := ("IMG" | "SEG" | "OCR" | "COR")
-PROCESSOR := [A-Z0-9\-]{3,}
+ID := FILEGRP + (".IMG")?
 ```
 ### Examples
 

--- a/mets.md
+++ b/mets.md
@@ -106,7 +106,8 @@ The `ID` MUST be unique inside the METS file.
 
 ```
 FILEID := ID + "_" + [0-9]{4}
-ID := "OCR-D-" + WORKFLOW_STEP + ("-" + PROCESSOR)?
+ID := "OCR-D-" + WORKFLOW_STEP + ("-" + FEATURE)* + ("-" + PROCESSOR)?
+FEATURE := ("BIN" | "CROP" | "DESKEW" | DESPECK" | "DEWARP" )
 WORKFLOW_STEP := ("IMG" | "SEG" | "OCR" | "COR")
 PROCESSOR := [A-Z0-9\-]{3,}
 ```
@@ -116,6 +117,7 @@ PROCESSOR := [A-Z0-9\-]{3,}
 --               | --
 `<mets:file ID="OCR-D-IMG_0001">`            | The unmanipulated source image
 `<mets:file ID="OCR-D-IMG-BIN_0001">`        | Black-and-White image
+`<mets:file ID="OCR-D-IMG-BIN-CROP_0001">`   | Cropped Black-and-White image
 
 ## Grouping files by page
 

--- a/mets.md
+++ b/mets.md
@@ -86,24 +86,14 @@ with the type of manipulation (`BIN-KRAKEN`).
 `<mets:fileGrp USE>` | Type of use for OCR-D
 --                                          | --
 `<mets:fileGrp USE="OCR-D-IMG">`            | The unmanipulated source images
-`<mets:fileGrp USE="OCR-D-IMG-BIN">`        | Black-and-White images
-`<mets:fileGrp USE="OCR-D-IMG-CROP">`       | Cropped images
-`<mets:fileGrp USE="OCR-D-IMG-DESKEW">`     | Deskewed images
-`<mets:fileGrp USE="OCR-D-IMG-DESPECK">`    | Despeckled images
-`<mets:fileGrp USE="OCR-D-IMG-DEWARP">`     | Dewarped images
 `<mets:fileGrp USE="OCR-D-SEG-REGION">`      | Region segmentation
 `<mets:fileGrp USE="OCR-D-SEG-LINE">`       | Line segmentation
 `<mets:fileGrp USE="OCR-D-SEG-WORD">`       | Word segmentation
 `<mets:fileGrp USE="OCR-D-SEG-GLYPH">`      | Glyph segmentation
-`<mets:fileGrp USE="OCR-D-OCR-TESS">`       | Tesseract OCR
-`<mets:fileGrp USE="OCR-D-OCR-ANY">`        | AnyOCR
-`<mets:fileGrp USE="OCR-D-COR-CIS">`        | CIS post-correction
-`<mets:fileGrp USE="OCR-D-COR-ASV">`        | ASV post-correction
-`<mets:fileGrp USE="OCR-D-GT-IMG-BIN">`     | Black-and-White images ground truth
-`<mets:fileGrp USE="OCR-D-GT-IMG-CROP">`    | Cropped images ground truth
-`<mets:fileGrp USE="OCR-D-GT-IMG-DESKEW">`  | Deskewed images ground truth
-`<mets:fileGrp USE="OCR-D-GT-IMG-DESPECK">` | Despeckled images ground truth
-`<mets:fileGrp USE="OCR-D-GT-IMG-DEWARP">`  | Dewarped images ground truth
+`<mets:fileGrp USE="OCR-D-OCR-TESS">`       | [Tesseract OCR](https://github.com/OCR-D/ocrd_tesserocr)
+`<mets:fileGrp USE="OCR-D-OCR-ANY">`        | [AnyOCR](https://github.com/OCR-D/ocrd_anybaseocr)
+`<mets:fileGrp USE="OCR-D-COR-CIS">`        | [CIS post-correction](https://github.com/cisocrgroup/ocrd_cis)
+`<mets:fileGrp USE="OCR-D-COR-ASV">`        | [ASV post-correction](https://github.com/ASVLeipzig/cor-asv-ann)
 `<mets:fileGrp USE="OCR-D-GT-SEG-REGION">`   | Region segmentation ground truth
 `<mets:fileGrp USE="OCR-D-GT-SEG-LINE">`    | Line segmentation ground truth
 `<mets:fileGrp USE="OCR-D-GT-SEG-WORD">`    | Word segmentation ground truth

--- a/mets.md
+++ b/mets.md
@@ -186,7 +186,13 @@ Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
 
 ## If in PAGE then in METS
 
-Every image URL referenced via `imageFileName` or the `filename` attribute of any `pc:AlternativeImage` MUST be represented in the METS file as a `mets:file` with corresponding `mets:FLocat@xlink:href`. 
+All URL used in `imageFilename` and `filename` attributes of
+`<pc:Page>`/`<pc:AlternativeImage>` MUST be referenced in a `mets:fileGrp` as the
+`@xlink:href` attribute of a `mets:file`. This MUST be the same file group as
+the PAGE-XML that was the result of the processing step that produced the
+`<pg:AlternativeImage>`. In other words: `<pg:AlternativeImage>` should be
+written to the same `mets:fileGrp` as its source PAGE-XML, which in most
+implementations will mean the same folder.
 
 ## Recording processing information in METS
 

--- a/mets.md
+++ b/mets.md
@@ -113,8 +113,10 @@ ID := FILEGRP + (".IMG")?
 `<mets:file ID>` | ID of the file for OCR-D
 --               | --
 `<mets:file ID="OCR-D-IMG_0001">`            | The unmanipulated source image
-`<mets:file ID="OCR-D-IMG-BIN_0001">`        | Black-and-White image
-`<mets:file ID="OCR-D-IMG-BIN-CROP_0001">`   | Cropped Black-and-White image
+`<mets:file ID="OCR-D-PRE-BIN_0001">`        | PAGE encapsulating the result from binarization
+`<mets:file ID="OCR-D-PRE-BIN.IMG_0001">`    | Black-and-white image
+`<mets:file ID="OCR-D-PRE-CROP_0001">`       | PAGE encapsulating the result from (binarization and) cropping
+`<mets:file ID="OCR-D-PRE-CROP.IMG_0001">`   | Cropped black-and-white image
 
 ## Grouping files by page
 

--- a/page.md
+++ b/page.md
@@ -27,7 +27,7 @@ All URL used in `imageFilename` and `filename` [MUST be referenced in a fileGrp
 in METS](https://ocr-d.de/en/spec/mets#if-in-page-then-in-mets). This MUST be
 the same file group as the PAGE-XML that was the result of the processing step
 that produced the `<pg:AlternativeImage>`. In other words:
-`<pg:AlternativeImage>` should be written to the same fileGrp as its source
+`<pg:AlternativeImage>` should be written to the same `<mets:fileGrp>` as its source
 PAGE-XML, which in most implementations will mean the same folder.
 
 ### Original image as imageFilename

--- a/page.md
+++ b/page.md
@@ -24,7 +24,11 @@ The `imageFilename` of the `<pg:Page>` and `filename` of the
 `<pg:AlternativeImage>` element MUST be a filename relative to the `mets.xml`.
 
 All URL used in `imageFilename` and `filename` [MUST be referenced in a fileGrp
-in METS](https://ocr-d.de/en/spec/mets#if-in-page-then-in-mets).
+in METS](https://ocr-d.de/en/spec/mets#if-in-page-then-in-mets). This MUST be
+the same file group as the PAGE-XML that was the result of the processing step
+that produced the `<pg:AlternativeImage>`. In other words:
+`<pg:AlternativeImage>` should be written to the same fileGrp as its source
+PAGE-XML, which in most implementations will mean the same folder.
 
 ### Original image as imageFilename
 


### PR DESCRIPTION
https://github.com/OCR-D/core/issues/505

The convention "all files in a filegroup must have the same mimetype" is obsolete.

AlternativeImages should be written to the same file group as the PAGE-XML they are referenced in first.