### PR TITLE
ocrd-tool schema: be less restrictive on input/ouptut_filegrp

### DIFF
--- a/ocrd_tool.schema.yml
+++ b/ocrd_tool.schema.yml
@@ -29,7 +29,8 @@ properties:
           - steps
           - executable
           - categories
-          - input_file_grp
+          # Not required because not all processors take input from a file group
+          # - input_file_grp
           # Not required because not all processors produce output files
           # - output_file_grp
         properties:
@@ -39,15 +40,18 @@ properties:
           input_file_grp:
             description: Input fileGrp@USE this tool expects by default
             type: array
-            items:
-              type: string
-              pattern: '^OCR-D-[A-Z0-9-]+$'
+            default: ['PLACEHOLDER']
+            # Naming convention is obsolete
+            #items:
+            #  type: string
+            #  pattern: '^OCR-D-[A-Z0-9-]+$'
           output_file_grp:
             description: Output fileGrp@USE this tool produces by default
             type: array
-            items:
-              type: string
-              pattern: '^OCR-D-[A-Z0-9-]+$'
+            # Naming convention is obsolete
+            #items:
+            #  type: string
+            #  pattern: '^OCR-D-[A-Z0-9-]+$'
           parameters:
             description: Object describing the parameters of a tool. Keys are parameter names, values sub-schemas.
             type: object


### PR DESCRIPTION
Designing the [`ocrd-sanitize` processor](https://github.com/OCR-D/core/issues/544) makes it obvious that the `input_file_grp`/`output_file_grp` are not only obsolete but an anti-pattern:

  * The semantics are unintuitive or rather nonsensical, examples of how file groups MIGHT be named (but never are in practice) do not help
  * There are use cases where the input is not strictly `mets:file`s from a `mets:fileGrp`. Since the core implementation depends on a single input file group (`Processor.input_files` property) we cannot just drop it though (hence the `["PLACEHOLDER"]` default)
  * The naming restriction on top of `input_file_grp`/`output_file_grp` makes it worse