### PR TITLE
revise processor resource spec, OCR-D/core#559

### DIFF
--- a/ocrd_tool.md
+++ b/ocrd_tool.md
@@ -27,16 +27,15 @@ should be resolved in the following way:
 * If `<fpath>` is an absolute path: Use as-is.
 * If `<fpath>` is a relative path, try resolving the following paths and return
   the first one found if any, otherwise abort with an error message stating so:
-  * `$CWD/<fpath>`
+  * `$CWD/ocrd-resources/<fpath>`
   * If an environment variable is defined that has the name of the processor in
     upper-case and with `-` replaced with `-` and followed by `_PATH` (e.g. for a processor
     `ocrd-dummy`, the variable would need to be called `OCRD_DUMMY_PATH`):
     * Split the variable value at `:` and try to resolve by appending `<fpath>`
       to each token and return the first found file if any
-  * `$VIRTUAL_ENV/share/<name-of-processor>/<fpath>`
-  * `$XDG_DATA_HOME/<name-of-processor>/<fpath>` (with `$HOME/.local/share` instead of `$XDG_DATA_HOME` if unset)
-  * `$XDG_CONFIG_HOME/<name-of-processor>/<fpath>` (with `$HOME/.config` instead of `$XDG_CONFIG_HOME` if unset)
-  * `/usr/local/share/<name-of-processor>/<fpath>`
+  * `$VIRTUAL_ENV/share/ocrd-resources/<name-of-processor>/<fpath>`
+  * `$XDG_DATA_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.local/share` instead of `$XDG_DATA_HOME` if unset)
+  * `$XDG_CONFIG_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.config` instead of `$XDG_CONFIG_HOME` if unset)
 
 ## Input / Output file groups
 

--- a/ocrd_tool.md
+++ b/ocrd_tool.md
@@ -37,7 +37,6 @@ should be resolved in the following way:
   * `$XDG_DATA_HOME/<name-of-processor>/<fpath>` (with `$HOME/.local/share` instead of `$XDG_DATA_HOME` if unset)
   * `$XDG_CONFIG_HOME/<name-of-processor>/<fpath>` (with `$HOME/.config` instead of `$XDG_CONFIG_HOME` if unset)
   * `/usr/local/share/<name-of-processor>/<fpath>`
-  * If it is a Python implementation: try to resolve with `pkg_resources.resource_filename(__name__, "<fpath>")`
 
 ## Input / Output file groups
 


### PR DESCRIPTION
~~I also haven't implemented the `/usr/local/share/<name-of-processor>` variant in OCR-D/core#559 yet - do we still need it?~~

* Drop the pkg_resources stuff
* Drop `/usr/local/share`
* Add intermediary directory `ocrd-resources` to make it easier to mount a host-folder of resources into a Docker image e.g.