### PR TITLE
file parameters: remove virtualenv, config, cache, add system

### DIFF
--- a/ocrd_tool.md
+++ b/ocrd_tool.md
@@ -34,8 +34,6 @@ should be resolved in the following way:
     * Split the variable value at `:` and try to resolve by appending `<fpath>`
       to each token and return the first found file if any
   * `$XDG_DATA_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.local/share` instead of `$XDG_DATA_HOME` if unset)
-  * `$XDG_CONFIG_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.config` instead of `$XDG_CONFIG_HOME` if unset)
-  * `$XDG_CACHE_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.cache` instead of `$XDG_CACHE_HOME` if unset)
   * `/usr/local/share/ocrd-resources/<name-of-processor>/<fpath>`
 
 ## Input / Output file groups

--- a/ocrd_tool.md
+++ b/ocrd_tool.md
@@ -33,9 +33,10 @@ should be resolved in the following way:
     `ocrd-dummy`, the variable would need to be called `OCRD_DUMMY_PATH`):
     * Split the variable value at `:` and try to resolve by appending `<fpath>`
       to each token and return the first found file if any
-  * `$VIRTUAL_ENV/share/ocrd-resources/<name-of-processor>/<fpath>`
   * `$XDG_DATA_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.local/share` instead of `$XDG_DATA_HOME` if unset)
   * `$XDG_CONFIG_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.config` instead of `$XDG_CONFIG_HOME` if unset)
+  * `$XDG_CACHE_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.cache` instead of `$XDG_CACHE_HOME` if unset)
+  * `/usr/local/share/ocrd-resources/<name-of-processor>/<fpath>`
 
 ## Input / Output file groups
 


### PR DESCRIPTION
As we noticed in https://github.com/OCR-D/ocrd-website/pull/196, `$VIRTUAL_ENV` should neither be the default nor even an option.

~~`$XDG_CACHE_HOME/ocrd-resources` is implemented in OCR-D/core#559 but was missing here.~~

Only XDG option is now `$XDG_DATA_HOME` (= `$HOME/.local/share` unless env var is overridden)

Reintroduces `/usr/local/share/ocrd-resources` as a system-wide fallback for cases where `$HOME` might vary, like in Docker.