### PR TITLE
add resource schema and resource_locations to ocrd-tool.json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [3.12.0] - 2021-01-26
+
+Changed:
+
+  * Resource lookup: Remove XDG_CONFIG_HOME and XDG_CACHE_HOME
+  * Resource lookup: Add `/usr/local/share/ocrd-resources`
+
 ## [3.11.0] - 2021-01-20
 
 Changed:
@@ -379,6 +386,7 @@ Removed
 Initial Release
 
 <!-- link-labels -->
+[3.12.0]: ../../compare/v3.12.0...v3.11.0
 [3.11.0]: ../../compare/v3.11.0...v3.10.0
 [3.10.0]: ../../compare/v3.10.0...v3.9.1
 [3.9.1]: ../../compare/v3.9.1...v3.9.0

--- a/ocrd_tool.md
+++ b/ocrd_tool.md
@@ -34,8 +34,6 @@ should be resolved in the following way:
     * Split the variable value at `:` and try to resolve by appending `<fpath>`
       to each token and return the first found file if any
   * `$XDG_DATA_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.local/share` instead of `$XDG_DATA_HOME` if unset)
-  * `$XDG_CONFIG_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.config` instead of `$XDG_CONFIG_HOME` if unset)
-  * `$XDG_CACHE_HOME/ocrd-resources/<name-of-processor>/<fpath>` (with `$HOME/.cache` instead of `$XDG_CACHE_HOME` if unset)
   * `/usr/local/share/ocrd-resources/<name-of-processor>/<fpath>`
 
 ## Input / Output file groups

--- a/ocrd_tool.schema.yml
+++ b/ocrd_tool.schema.yml
@@ -126,3 +126,52 @@ properties:
                 - layout/segmentation/word
                 - layout/segmentation/classification
                 - layout/analysis
+          resource_locations:
+            type: array
+            description: The locations in the filesystem this processor supports for resource lookup
+            default: ['data', 'cwd', 'system']
+            items:
+              type: string
+              enum: ['data', 'cwd', 'system']
+          resources:
+            type: array
+            description: Resources for this processor
+            items:
+              type: object
+              additionalProperties: false
+              required:
+                - url
+                - description
+                - name
+                - size
+              properties:
+                url:
+                  type: string
+                  description: URLs of all components of this resource
+                description:
+                  type: string
+                  description: A description of the resource
+                name:
+                  type: string
+                  description: Name to store the resource as
+                type:
+                  type: string
+                  enum: ['file', 'github-dir', 'tarball']
+                  default: file
+                  description: Type of the URL
+                parameter_usage:
+                  type: string
+                  description: Defines how the parameter is to be used
+                  enum: ['as-is', 'without-extension']
+                  default: 'as-is'
+                path_in_archive:
+                  type: string
+                  description: if type is archive, the resource is at this location in the archive
+                  default: '.'
+                version_range:
+                  type: string
+                  description: Range of supported versions, syntax like in PEP 440
+                  default: '>= 0.0.1'
+                size:
+                  type: number
+                  description: Size of the resource in bytes


### PR DESCRIPTION
Adds two new properties to the `tools` list items in `ocrd-tool.json`:

* `resources`: List resources that can be used with this processor, to be used with OCR-D/core's `ocrd resmgr` CLI and resource lookup mechanism
* `resource_locations`: By default, resource's are looked up in `data` (`$XDG_DATA_HOME`), `cwd` and `system` (`/usr/local/share/ocrd-resources`). Since not all processors can support the full range of locations (notably ocrd_tesserocr can look only in one location for models), this allows restricting the locations to look for this processor.

Until now, we're maintaining a [central resource registry](https://github.com/OCR-D/core/blob/master/ocrd/ocrd/resource_list.yml) in OCR-D/core. We want to decentralize this, allowing processor developers to list resources in their own ocrd-tool.json.