### PR TITLE
fix list item visibility in ocrd_zip docu

### DIFF
--- a/ocrd_zip.md
+++ b/ocrd_zip.md
@@ -49,7 +49,7 @@ the full definition](#appendix-a)):
   * [`Ocrd-Identifier`](#ocrd-identifier): A globally unique identifier for this bag
   * [`Ocrd-Base-Version-Checksum`](#ocrd-base-version-checksum): Checksum of the version this bag is based on
 * `bag-info.txt` MAY additionally contain these tags:
-  * [`Ocrd-Mets`]: Alternative path to the mets.xml file, relative to `/data`, if its path IS NOT `mets.xml`
+  * [`Ocrd-Mets`](#ocrd-mets): Alternative path to the mets.xml file, relative to `/data`, if its path IS NOT `mets.xml`
   * [`Ocrd-Manifestation-Depth`](#ocrd-manifestation-depth): Whether all URL are dereferenced as files or only some
 
 ### `BagIt-Profile-Identifier`


### PR DESCRIPTION
without this addition the whole bullet point for Ocrd-Mets is not visible in the resulting html