### PR TITLE
added missing change for bagit-profile-json-url

### DIFF
--- a/ocrd_zip.md
+++ b/ocrd_zip.md
@@ -53,7 +53,7 @@ the full definition](#appendix-a)):
 
 ### `BagIt-Profile-Identifier`
 
-The `BagIt-Profile-Identifier` must be the string `https://ocr-d.de/bagit-profile.json`.
+The `BagIt-Profile-Identifier` must be the string `https://ocr-d.de/en/spec/bagit-profile.json`.
 
 ### `Ocrd-Mets`
 


### PR DESCRIPTION
I think one occurrence of bagit-profile url was overlooked during the last change regarding the same topic.