### PR TITLE
Mets updates

### DIFF
--- a/mets.md
+++ b/mets.md
@@ -46,11 +46,7 @@ To add agent information, a processor must:
 </mets:agent>
 ```
 
-### 1.3 Media Type for PAGE XML
-
-Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
-
-### 1.4 Always use URL or relative filenames
+### 1.3 Always use URL or relative filenames
 
 Always use URL, except for files located in the directory or any subdirectories of the METS file.
 
@@ -215,6 +211,10 @@ ID := FILEGRP + (".IMG")?
 `<mets:file ID="OCR-D-PRE-CROP_0001">`       | PAGE encapsulating the result from (binarization and) cropping
 `<mets:file ID="OCR-D-PRE-CROP.IMG_0001">`   | Cropped black-and-white image
 
+### 4.2 `@MIMETYPE` syntax
+
+Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
+
 ## 5) Grouping files by page `mets:structMap`
 
 ### 5.1 Grouping files by page
@@ -260,7 +260,7 @@ attributes in `structMap` | description
 
 ## 6) Ranges of pages `mets:structLink`
 
-The `mets:structLink`describes the range of pages in part of document.
+The `mets:structLink` describes the ranges of pages in part of a document.
 
 #### Example
 

--- a/mets.md
+++ b/mets.md
@@ -196,21 +196,6 @@ with the type of manipulation (`BIN-KRAKEN`).
 `<mets:fileGrp USE="OCR-D-GT-SEG-WORD">`   | Word segmentation ground truth
 `<mets:fileGrp USE="OCR-D-GT-SEG-GLYPH">`  | Glyph segmentation ground truth
 
-### 3.2 File Group `@USE="FULLDOWNLOAD_..."`
-
-For `mets:file` entries representative of the publication **as a whole**, the `ID` attribute MUST have  prefix `FULLDOWNLOAD_`, followed by the file format (`TEI`, `ALTO`, `hOCR`, `HTML`, `TXT`, `COCO`, `PDF`).
-
-These entries SHOULD be referenced in the [structMap](#ocr-d-structmap) under `/mets:mets/mets:structMap[@TYPE="PHYSICAL"]/mets:div/mets:fptr` (i.e. the top-level `mets:div` element).
-
-They MAY reside in the same `mets:fileGrp` as per-page files of the same type, or in a separate one.
-
-#### Example
-`<mets:file ID>` | ID of the file for OCR-D
---               | --
-`<mets:file ID="FULLDOWNLOAD_TEI"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format.
-`<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format. Version one.
-`<mets:file ID="FULLDOWNLOAD_TEI_02"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format, a second Version.
-
 ## 4) Files `mets:file` 
 
 <a id="file-id-syntax"/>
@@ -238,6 +223,21 @@ ID := FILEGRP + (".IMG")?
 ### 4.2 `@MIMETYPE` syntax
 
 Every `mets:file` element representing a PAGE file MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
+
+### 4.3 File Group `@USE="FULLDOWNLOAD_..."`
+
+For `mets:file` entries representative of the publication **as a whole**, the `ID` attribute MUST have  prefix `FULLDOWNLOAD_`, followed by the file format (`TEI`, `ALTO`, `hOCR`, `HTML`, `TXT`, `COCO`, `PDF`).
+
+These entries SHOULD be referenced in the [structMap](#ocr-d-structmap) under `/mets:mets/mets:structMap[@TYPE="PHYSICAL"]/mets:div/mets:fptr` (i.e. the top-level `mets:div` element).
+
+They MAY reside in the same `mets:fileGrp` as per-page files of the same type, or in a separate one.
+
+#### Example
+`<mets:file ID>` | ID of the file for OCR-D
+--               | --
+`<mets:file ID="FULLDOWNLOAD_TEI"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format.
+`<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format. Version one.
+`<mets:file ID="FULLDOWNLOAD_TEI_02"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format, a second Version.
 
 ## 5) Grouping files by page `mets:structMap`
 

--- a/mets.md
+++ b/mets.md
@@ -208,7 +208,7 @@ They MAY reside in the same `mets:fileGrp` as per-page files of the same type, o
 `<mets:file ID>` | ID of the file for OCR-D
 --               | --
 `<mets:file ID="FULLDOWNLOAD_TEI"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format.
-`<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/pdf">`            | The digitised publication or book in TEI format. Version one.
+`<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format. Version one.
 `<mets:file ID="FULLDOWNLOAD_TEI_02"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format, a second Version.
 
 ## 4) Files `mets:file` 

--- a/mets.md
+++ b/mets.md
@@ -18,7 +18,30 @@ For this purpose, the METS file MUST contain a `mods:identifier` that must conta
 * `handle`
 * `url`
 
-### 1.2 Recording processing information in METS
+### 1.2 Always use URL or relative filenames
+
+Always use URL, except for files located in the directory or any subdirectories of the METS file.
+
+#### Example
+
+```sh
+/tmp/foo/ws1
+├── mets.xml
+├── foo.tif
+└── foo.xml
+```
+
+Valid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
+* `foo.xml`
+* `foo.tif`
+* `file://foo.tif`
+
+Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
+* `/tmp/foo/ws1/foo.xml` (absolute path)
+* `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
+* `file:///foo.tif` (relative path written as absolute path)
+
+### 1.3 Recording processing information in METS
 
 Processors should add information to the METS metadata header to indicate that
 they changed the METS. This information is mainly for human consumption to get
@@ -46,32 +69,19 @@ To add agent information, a processor must:
 </mets:agent>
 ```
 
-### 1.3 Always use URL or relative filenames
-
-Always use URL, except for files located in the directory or any subdirectories of the METS file.
-
-#### Example
-
-```sh
-/tmp/foo/ws1
-├── mets.xml
-├── foo.tif
-└── foo.xml
-```
-
-Valid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
-* `foo.xml`
-* `foo.tif`
-* `file://foo.tif`
-
-Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
-* `/tmp/foo/ws1/foo.xml` (absolute path)
-* `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
-* `file:///foo.tif` (relative path written as absolute path)
-
 ## 2) Images
 
-### 2.1 Pixel density of images must be explicit and high enough
+### 2.1 If in PAGE then in METS
+
+All URL used in `imageFilename` and `filename` attributes of
+`<pc:Page>`/`<pc:AlternativeImage>` MUST be referenced in a `mets:fileGrp` as the
+`@xlink:href` attribute of a `mets:file`. This MUST be the same file group as
+the PAGE-XML that was the result of the processing step that produced the
+`<pg:AlternativeImage>`. In other words: `<pg:AlternativeImage>` should be
+written to the same `mets:fileGrp` as its source PAGE-XML, which in most
+implementations will mean the same folder.
+
+### 2.2 Pixel density of images must be explicit and high enough
 
 The pixel density is the ratio of the number of pixels that represent a a unit of measure of the scanned object. It is typically measured in pixels per inch (PPI, a.k.a. DPI).
 
@@ -96,16 +106,6 @@ $> exiftool output.tif |grep 'X Resolution'
 However, since technical metadata about pixel density is so often lost in
 conversion or inaccurate, processors should assume **300 ppi** for images with
 missing or suspiciously low pixel density metadata.
-
-### 2.2 If in PAGE then in METS
-
-All URL used in `imageFilename` and `filename` attributes of
-`<pc:Page>`/`<pc:AlternativeImage>` MUST be referenced in a `mets:fileGrp` as the
-`@xlink:href` attribute of a `mets:file`. This MUST be the same file group as
-the PAGE-XML that was the result of the processing step that produced the
-`<pg:AlternativeImage>`. In other words: `<pg:AlternativeImage>` should be
-written to the same `mets:fileGrp` as its source PAGE-XML, which in most
-implementations will mean the same folder.
 
 ### 2.3 No multi-page images
 

--- a/mets.md
+++ b/mets.md
@@ -1,14 +1,81 @@
 # Requirements on handling METS/PAGE
 
-OCR-D has decided to base its data exchange format on top of [METS](http://www.loc.gov/standards/mets/).
+OCR-D has decided to base its data exchange format on [METS](http://www.loc.gov/standards/mets/). This document defines a set of conventions and mechanism for using METS files within OCR-D. The basis for this is the METS Application Profile
+for digitised media by the [DFG-Viewer](http://dfg-viewer.de/) (current version: [2.3.1](http://dfg-viewer.de/fileadmin/groups/dfgviewer/METS-Anwendungsprofil_2.3.1.pdf)).
 
-For layout and text recognition results, the primary exchange format is [PAGE](https://github.com/OCR-D/PAGE-XML)
+For layout and text recognition results, the primary exchange format in OCR-D is [PAGE](https://github.com/OCR-D/PAGE-XML). Conventions for PAGE are outlined in [a separate document](page).
 
-This document defines a set of conventions and mechanism for using METS.
+# 1) Metadata
 
-Conventions for PAGE are outlined in [a separate document](page)
+## 1.1 Unique ID for the document processed
 
-## Pixel density of images must be explicit and high enough
+METS provided to the MP must be uniquely addressable within the global library community.
+
+For this purpose, the METS file MUST contain a `mods:identifier` that must contain a globally unique identifier for the document and have a `type` attribute with a value of, in order of preference:
+
+* `purl`
+* `urn`
+* `handle`
+* `url`
+
+## 1.2 Recording processing information in METS
+
+Processors should add information to the METS metadata header to indicate that
+they changed the METS. This information is mainly for human consumption to get
+an overview of the software agents involved in the METS file's creation. More
+detailed or machine-actionable provenance information is outside the scope of
+the processor.
+
+To add agent information, a processor must:
+
+1) locate the first `mets:metsHdr` `M`.
+2) Add to `M` a new `mets:agent` `A` with these attributes
+  - `TYPE` must be the string `OTHER`
+  - `OTHERTYPE` must be the string `SOFTWARE`
+  - `ROLE` must be the string `OTHER`
+  - `OTHERROLE` must be the processing step this processor provided, from the list in [the ocrd-tool.json spec](ocrd_tool#definition)
+3) Add to `A` a `mets:name` `N` that should include, in free-text form, these data points
+  - Name of the processor, e.g. the name of the executable from `ocrd-tool.json`
+  - Version of the processor, e.g. from `ocrd-tool.json`
+
+**Example:**
+
+```xml
+<mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="OTHER" OTHERROLE="preprocessing/optimization/binarization">
+  <mets:name>ocrd_tesserocr v0.1.2</mets:name>
+</mets:agent>
+```
+
+## 1.3 Media Type for PAGE XML
+
+Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
+
+## 1.4 Always use URL or relative filenames
+
+Always use URL, except for files located in the directory or any subdirectories of the METS file.
+
+### Example
+
+```sh
+/tmp/foo/ws1
+├── mets.xml
+├── foo.tif
+└── foo.xml
+```
+
+Valid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
+* `foo.xml`
+* `foo.tif`
+* `file://foo.tif`
+
+Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
+* `/tmp/foo/ws1/foo.xml` (absolute path)
+* `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
+* `file:///foo.tif` (relative path written as absolute path)
+
+# 2) Images
+
+## 2.1 Pixel density of images must be explicit and high enough
 
 The pixel density is the ratio of the number of pixels that represent a a unit of measure of the scanned object. It is typically measured in pixels per inch (PPI, a.k.a. DPI).
 
@@ -34,7 +101,17 @@ However, since technical metadata about pixel density is so often lost in
 conversion or inaccurate, processors should assume **300 ppi** for images with
 missing or suspiciously low pixel density metadata.
 
-## No multi-page images
+## 2.2 If in PAGE then in METS
+
+All URL used in `imageFilename` and `filename` attributes of
+`<pc:Page>`/`<pc:AlternativeImage>` MUST be referenced in a `mets:fileGrp` as the
+`@xlink:href` attribute of a `mets:file`. This MUST be the same file group as
+the PAGE-XML that was the result of the processing step that produced the
+`<pg:AlternativeImage>`. In other words: `<pg:AlternativeImage>` should be
+written to the same `mets:fileGrp` as its source PAGE-XML, which in most
+implementations will mean the same folder.
+
+## 2.3 No multi-page images
 
 Image formats like TIFF support encoding multiple images in a single file.
 
@@ -42,19 +119,18 @@ Data providers MUST provide single-image TIFF files.
 
 OCR-D processors MUST raise an exception if they encounter multi-image TIFF files.
 
-## Unique ID for the document processed
+## 2.4 Images and coordinates
 
-METS provided to the MP must be uniquely addressable within the global library community.
+Coordinates are always absolute, i.e. relative to extent defined in the `imageWidth`/`imageHeight` attribute of the nearest `<pc:Page>`.
 
-For this purpose, the METS file MUST contain a `mods:identifier` that must contain a globally unique identifier for the document and have a `type` attribute with a value of, in order of preference:
+When a processor wants to access the image of a layout element like a TextRegion or TextLine, the algorithm should be:
 
-* `purl`
-* `urn`
-* `handle`
-* `url`
+- If the element in question has an attribute `imageFilename`, resolve this value
+- If the element has a `<pc:Coords>` subelement, resolve by passing the attribute `imageFilename` of the nearest `<pc:Page>` and the `points` attribute of the `<pc:Coords>` element
 
+# 3) File group `mets:fileGrp`
 
-## File Group USE syntax
+## 3.1 File Group `@USE` syntax
 
 All `mets:fileGrp` MUST have a **unique** `USE` attribute that hints at the provenance of the files and must be a valid [`xsd:ID`](https://www.w3.org/TR/xmlschema11-2/#ID).
 
@@ -104,6 +180,23 @@ with the type of manipulation (`BIN-KRAKEN`).
 `<mets:fileGrp USE="OCR-D-GT-SEG-WORD">`   | Word segmentation ground truth
 `<mets:fileGrp USE="OCR-D-GT-SEG-GLYPH">`  | Glyph segmentation ground truth
 
+## 3.2 File Group `@USE="FULLDOWNLOAD_..."`
+
+#### Fulldownload
+
+For `mets:file` entries representative of the publication **as a whole**, the `ID` attribute MUST have  prefix `FULLDOWNLOAD_`, followed by the file format (`TEI`, `ALTO`, `hOCR`, `HTML`, `TXT`, `COCO`, `PDF`).
+
+These entries SHOULD be referenced in the [structMap](#ocr-d-structmap) under `/mets:mets/mets:structMap[@TYPE="PHYSICAL"]/mets:fptr`.
+
+##### Examples
+`<mets:file ID>` | ID of the file for OCR-D
+--               | --
+`<mets:file ID="FULLDOWNLOAD_TEI"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format.
+`<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/pdf">`            | The digitised publication or book in TEI format. Version one.
+`<mets:file ID="FULLDOWNLOAD_TEI_02"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format, a second Version.
+
+# 4) File `mets:file` 
+
 ## File ID syntax
 
 Each `mets:file` must have an `ID` attribute. The `ID` attribute of a `mets:file` SHOULD be the `USE` of the containing `mets:fileGrp` combined with a 4-zero-padded number.
@@ -123,7 +216,9 @@ ID := FILEGRP + (".IMG")?
 `<mets:file ID="OCR-D-PRE-CROP_0001">`       | PAGE encapsulating the result from (binarization and) cropping
 `<mets:file ID="OCR-D-PRE-CROP.IMG_0001">`   | Cropped black-and-white image
 
-## Grouping files by page
+# 5) Grouping files by page `mets:structMap`
+
+## 5.1 Grouping files by page
 
 Every METS file MUST have exactly one physical map that contains a single
 `mets:div[@TYPE="physSequence"]` which in turn must contain a
@@ -152,78 +247,85 @@ encodings of the same page.
 </mets:structMap>
 ```
 
-## Images and coordinates
+## 5.2 OCR-D `mets:structMap`
 
-Coordinates are always absolute, i.e. relative to extent defined in the `imageWidth`/`imageHeight` attribute of the nearest `<pc:Page>`.
+A METS may contain different `mets:structMap` entries, differentiated by their `TYPE` attribute (e.g. `LOGICAL`, `PHYSICAL, ...`). 
+* A `mets:structMap` with `TYPE="PHYSICAL"` is mandatory.
+* The _logical_ document structure detected by _library or archive_ MUST be described by `TYPE="LOGICAL"`.
+* The _logical_ document structure detected by _OCR-D software_ MUST be described by `TYPE="OCR-D-LOGICAL"`.
 
-When a processor wants to access the image of a layout element like a TextRegion or TextLine, the algorithm should be:
+attributes in `structMap` | description
+--                        | --
+`LABEL` | contains the recognized text of a structuring component, e.g. the title of a chapter
+`TYPE` | contains the type of a structuring component according to some standardized, controlled vocabulary (see [DFG-Viewer: structural data set](https://dfg-viewer.de/strukturdatenset/)), e.g. `chapter`
 
-- If the element in question has an attribute `imageFilename`, resolve this value
-- If the element has a `<pc:Coords>` subelement, resolve by passing the attribute `imageFilename` of the nearest `<pc:Page>` and the `points` attribute of the `<pc:Coords>` element
+# 6) Ranges of pages `mets:structLink`
 
+### `mets:structLink`
 
+The `mets:structLink`describes the range of pages in part of document.
 
-## Media Type for PAGE XML
-
-Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
-
-## Always use URL or relative filenames
-
-Always use URL, except for files located in the directory or any subdirectories of the METS file.
 
 ### Example
 
-```sh
-/tmp/foo/ws1
-├── mets.xml
-├── foo.tif
-└── foo.xml
-```
-
-Valid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
-* `foo.xml`
-* `foo.tif`
-* `file://foo.tif`
-
-Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
-* `/tmp/foo/ws1/foo.xml` (absolute path)
-* `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
-* `file:///foo.tif` (relative path written as absolute path)
-
-## If in PAGE then in METS
-
-All URL used in `imageFilename` and `filename` attributes of
-`<pc:Page>`/`<pc:AlternativeImage>` MUST be referenced in a `mets:fileGrp` as the
-`@xlink:href` attribute of a `mets:file`. This MUST be the same file group as
-the PAGE-XML that was the result of the processing step that produced the
-`<pg:AlternativeImage>`. In other words: `<pg:AlternativeImage>` should be
-written to the same `mets:fileGrp` as its source PAGE-XML, which in most
-implementations will mean the same folder.
-
-## Recording processing information in METS
-
-Processors should add information to the METS metadata header to indicate that
-they changed the METS. This information is mainly for human consumption to get
-an overview of the software agents involved in the METS file's creation. More
-detailed or machine-actionable provenance information is outside the scope of
-the processor.
-
-To add agent information, a processor must:
-
-1) locate the first `mets:metsHdr` `M`.
-2) Add to `M` a new `mets:agent` `A` with these attributes
-  - `TYPE` must be the string `OTHER`
-  - `OTHERTYPE` must be the string `SOFTWARE`
-  - `ROLE` must be the string `OTHER`
-  - `OTHERROLE` must be the processing step this processor provided, from the list in [the ocrd-tool.json spec](ocrd_tool#definition)
-3) Add to `A` a `mets:name` `N` that should include, in free-text form, these data points
-  - Name of the processor, e.g. the name of the executable from `ocrd-tool.json`
-  - Version of the processor, e.g. from `ocrd-tool.json`
-
-**Example:**
-
 ```xml
-<mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="OTHER" OTHERROLE="preprocessing/optimization/binarization">
-  <mets:name>ocrd_tesserocr v0.1.2</mets:name>
-</mets:agent>
+<mets:fileGrp USE="OCR-D-IMG">
+    <mets:file ID="OCR-D-IMG_0001" >...</mets:file>
+</mets:fileGrp>
+<mets:fileGrp USE="OCR-D-OCR">
+    <mets:file ID="OCR-D-OCR_0001" >...</mets:file>
+</mets:fileGrp>
+<mets:structMap TYPE="OCR-D-LOGICAL">
+  <mets:div DMDID="dmdSec_0001" ADMID="amdSec_0001" ID="OCR-D-loc_0001">
+    <mets:div ID="OCR-D-loc_d5e320" TYPE="chapter" LABEL="KapıteI 1">
+    <mets:div ID="OCR-D-loc_d7e560" TYPE="chapter" LABEL="Unterkapitel"/>
+    </mets:div>
+    <mets:div ID="OCR-D-loc_d9e376" TYPE="chapter" LABEL="Kapidel 2"/>
+   </mets:div>
+</mets:structMap>
+<mets:structMap TYPE="LOGICAL">
+   <mets:div TYPE="Monograph" DMDID="dmdSec_0001" ADMID="amdSec_0001" ID="loc_0001">
+    <mets:div ID="loc_d1e410" TYPE="chapter" LABEL="Kapitel 1"/>
+    <mets:div ID="loc_d1e451" TYPE="chapter" LABEL="Kapitel 2"/>
+   </mets:div>
+</mets:structMap>
+<mets:structMap TYPE="PHYSICAL">
+  <mets:div ID="PHYS_0000" TYPE="physSequence">
+    <mets:div ID="PHYS_0001" TYPE="page">
+      <mets:fptr FILEID="OCR-D-IMG_0001"/>
+      <mets:fptr FILEID="OCR-D-OCR_0001"/>
+    </mets:div>
+  </mets:div>
+</mets:structMap>
+<mets:structLink>
+
+<!-- Library-Part-->   
+<mets:smLink xlink:from="loc_0001" xlink:to="PHYS_0000"/>
+<mets:smLink xlink:from="loc_d1e410" xlink:to="PHYS_0001"/>
+<mets:smLink xlink:from="loc_d1e410" xlink:to="PHYS_0002"/>
+<mets:smLink xlink:from="loc_d1e410" xlink:to="PHYS_0003"/>
+<mets:smLink xlink:from="loc_d1e410" xlink:to="PHYS_0004"/>
+<mets:smLink xlink:from="loc_d1e451" xlink:to="PHYS_0005"/>
+<mets:smLink xlink:from="loc_d1e451" xlink:to="PHYS_0006"/>
+
+ <!-- OCR-D-Part-->   
+<mets:smLink xlink:from="OCR-D-loc_0001" xlink:to="PHYS_0000"/>
+<!-- Kapitel 1-->
+<mets:smLink xlink:from="OCR-D-loc_d5e320" xlink:to="PHYS_0001"/>
+<mets:smLink xlink:from="OCR-D-loc_d5e320" xlink:to="PHYS_0002"/>
+<mets:smLink xlink:from="OCR-D-loc_d5e320" xlink:to="PHYS_0003"/>
+<mets:smLink xlink:from="OCR-D-loc_d5e320" xlink:to="PHYS_0004"/>
+
+<!-- Unter-Kapitel zu 1-->
+<mets:smLink xlink:from="OCR-D-loc_d7e560" xlink:to="PHYS_0002"/>
+<mets:smLink xlink:from="OCR-D-loc_d7e560" xlink:to="PHYS_0003"/>
+<mets:smLink xlink:from="OCR-D-loc_d7e560" xlink:to="PHYS_0004"/>
+
+<!-- Kapitel 2-->    
+<mets:smLink xlink:from="OCR-D-loc_d7e560" xlink:to="PHYS_0005"/>
+<mets:smLink xlink:from="OCR-D-loc_d7e560" xlink:to="PHYS_0006"/>
+
+</mets:structLink>
 ```
+
+

--- a/mets.md
+++ b/mets.md
@@ -211,7 +211,7 @@ They MAY reside in the same `mets:fileGrp` as per-page files of the same type, o
 `<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/pdf">`            | The digitised publication or book in TEI format. Version one.
 `<mets:file ID="FULLDOWNLOAD_TEI_02"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format, a second Version.
 
-## 4) File `mets:file` 
+## 4) Files `mets:file` 
 
 <a id="file-id-syntax"/>
 ### 4.1 File ID syntax

--- a/mets.md
+++ b/mets.md
@@ -7,6 +7,7 @@ For layout and text recognition results, the primary exchange format in OCR-D is
 
 ## 1) Metadata
 
+<a id="unique-id-for-the-document-processed"/>
 ### 1.1 Unique ID for the document processed
 
 METS provided to the MP must be uniquely addressable within the global library community.
@@ -18,6 +19,7 @@ For this purpose, the METS file MUST contain a `mods:identifier` that must conta
 * `handle`
 * `url`
 
+<a id="always-use-url-or-relative-filenames"/>
 ### 1.2 Always use URL or relative filenames
 
 Always use URL, except for files located in the directory or any subdirectories of the METS file.
@@ -41,6 +43,7 @@ Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
 * `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
 * `file:///foo.tif` (relative path written as absolute path)
 
+<a id="recording-processing-information-in-mets"/>
 ### 1.3 Recording processing information in METS
 
 Processors should add information to the METS metadata header to indicate that
@@ -71,6 +74,7 @@ To add agent information, a processor must:
 
 ## 2) Images
 
+<a id="if-in-page-then-in-mets"/>
 ### 2.1 If in PAGE then in METS
 
 All URL used in `imageFilename` and `filename` attributes of
@@ -81,6 +85,7 @@ the PAGE-XML that was the result of the processing step that produced the
 written to the same `mets:fileGrp` as its source PAGE-XML, which in most
 implementations will mean the same folder.
 
+<a id="pixel-density-of-images-must-be-explicit-and-high-enough"/>
 ### 2.2 Pixel density of images must be explicit and high enough
 
 The pixel density is the ratio of the number of pixels that represent a a unit of measure of the scanned object. It is typically measured in pixels per inch (PPI, a.k.a. DPI).
@@ -107,6 +112,7 @@ However, since technical metadata about pixel density is so often lost in
 conversion or inaccurate, processors should assume **300 ppi** for images with
 missing or suspiciously low pixel density metadata.
 
+<a id="no-multi-page-images"/>
 ### 2.3 No multi-page images
 
 Image formats like TIFF support encoding multiple images in a single file.
@@ -115,6 +121,7 @@ Data providers MUST provide single-image TIFF files.
 
 OCR-D processors MUST raise an exception if they encounter multi-image TIFF files.
 
+<a id="images-and-coordinates"/>
 ### 2.4 Images and coordinates
 
 Coordinates are always absolute, i.e. relative to extent defined in the `imageWidth`/`imageHeight` attribute of the nearest `<pc:Page>`.
@@ -126,6 +133,7 @@ When a processor wants to access the image of a layout element like a TextRegion
 
 ## 3) File group `mets:fileGrp`
 
+<a id="file-group-use-syntax"/>
 ### 3.1 File Group `@USE` syntax
 
 All `mets:fileGrp` MUST have a **unique** `USE` attribute that hints at the provenance of the files and must be a valid [`xsd:ID`](https://www.w3.org/TR/xmlschema11-2/#ID).
@@ -191,6 +199,7 @@ These entries SHOULD be referenced in the [structMap](#ocr-d-structmap) under `/
 
 ## 4) File `mets:file` 
 
+<a id="file-id-syntax"/>
 ### 4.1 File ID syntax
 
 Each `mets:file` must have an `ID` attribute. The `ID` attribute of a `mets:file` SHOULD be the `USE` of the containing `mets:fileGrp` combined with a 4-zero-padded number.
@@ -217,6 +226,7 @@ Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attrib
 
 ## 5) Grouping files by page `mets:structMap`
 
+<a id="grouping-files-by-page"/>
 ### 5.1 Grouping files by page
 
 Every METS file MUST have exactly one physical map that contains a single

--- a/mets.md
+++ b/mets.md
@@ -131,7 +131,8 @@ OCR-D processors MUST raise an exception if they encounter multi-image TIFF file
 
 Coordinates in a PAGE-XML are always absolute, i.e. relative to extent defined in the `imageWidth` / `imageHeight` attributes of the top-level `pc:Page`.
 
-When a processor wants to access the image of a layout element like a TextRegion or TextLine, the algorithm should be:
+
+When a processor wants to access the image of a layout element like a `pc:TextRegion` or `pc:TextLine`, the algorithm should be:
 
 - If the element in question has an attribute `imageFilename`, resolve this value
 - Else if the element in question has a subelement `pc:AlternativeImage` with attribute `filename`, resolve this value

--- a/mets.md
+++ b/mets.md
@@ -5,9 +5,9 @@ for digitised media by the [DFG-Viewer](http://dfg-viewer.de/) (current version:
 
 For layout and text recognition results, the primary exchange format in OCR-D is [PAGE](https://github.com/OCR-D/PAGE-XML). Conventions for PAGE are outlined in [a separate document](page).
 
-# 1) Metadata
+## 1) Metadata
 
-## 1.1 Unique ID for the document processed
+### 1.1 Unique ID for the document processed
 
 METS provided to the MP must be uniquely addressable within the global library community.
 
@@ -18,7 +18,7 @@ For this purpose, the METS file MUST contain a `mods:identifier` that must conta
 * `handle`
 * `url`
 
-## 1.2 Recording processing information in METS
+### 1.2 Recording processing information in METS
 
 Processors should add information to the METS metadata header to indicate that
 they changed the METS. This information is mainly for human consumption to get
@@ -38,7 +38,7 @@ To add agent information, a processor must:
   - Name of the processor, e.g. the name of the executable from `ocrd-tool.json`
   - Version of the processor, e.g. from `ocrd-tool.json`
 
-**Example:**
+#### Example
 
 ```xml
 <mets:agent TYPE="OTHER" OTHERTYPE="SOFTWARE" ROLE="OTHER" OTHERROLE="preprocessing/optimization/binarization">
@@ -46,15 +46,15 @@ To add agent information, a processor must:
 </mets:agent>
 ```
 
-## 1.3 Media Type for PAGE XML
+### 1.3 Media Type for PAGE XML
 
 Every `<mets:file>` representing a PAGE document MUST have its `MIMETYPE` attribute set to `application/vnd.prima.page+xml`.
 
-## 1.4 Always use URL or relative filenames
+### 1.4 Always use URL or relative filenames
 
 Always use URL, except for files located in the directory or any subdirectories of the METS file.
 
-### Example
+#### Example
 
 ```sh
 /tmp/foo/ws1
@@ -73,9 +73,9 @@ Invalid `mets:FLocat/@xlink:href` in `/tmp/foo/ws1/mets.xml`:
 * `file:///tmp/foo/ws1/foo.tif` (file URL scheme with absolute path)
 * `file:///foo.tif` (relative path written as absolute path)
 
-# 2) Images
+## 2) Images
 
-## 2.1 Pixel density of images must be explicit and high enough
+### 2.1 Pixel density of images must be explicit and high enough
 
 The pixel density is the ratio of the number of pixels that represent a a unit of measure of the scanned object. It is typically measured in pixels per inch (PPI, a.k.a. DPI).
 
@@ -101,7 +101,7 @@ However, since technical metadata about pixel density is so often lost in
 conversion or inaccurate, processors should assume **300 ppi** for images with
 missing or suspiciously low pixel density metadata.
 
-## 2.2 If in PAGE then in METS
+### 2.2 If in PAGE then in METS
 
 All URL used in `imageFilename` and `filename` attributes of
 `<pc:Page>`/`<pc:AlternativeImage>` MUST be referenced in a `mets:fileGrp` as the
@@ -111,7 +111,7 @@ the PAGE-XML that was the result of the processing step that produced the
 written to the same `mets:fileGrp` as its source PAGE-XML, which in most
 implementations will mean the same folder.
 
-## 2.3 No multi-page images
+### 2.3 No multi-page images
 
 Image formats like TIFF support encoding multiple images in a single file.
 
@@ -119,7 +119,7 @@ Data providers MUST provide single-image TIFF files.
 
 OCR-D processors MUST raise an exception if they encounter multi-image TIFF files.
 
-## 2.4 Images and coordinates
+### 2.4 Images and coordinates
 
 Coordinates are always absolute, i.e. relative to extent defined in the `imageWidth`/`imageHeight` attribute of the nearest `<pc:Page>`.
 
@@ -128,9 +128,9 @@ When a processor wants to access the image of a layout element like a TextRegion
 - If the element in question has an attribute `imageFilename`, resolve this value
 - If the element has a `<pc:Coords>` subelement, resolve by passing the attribute `imageFilename` of the nearest `<pc:Page>` and the `points` attribute of the `<pc:Coords>` element
 
-# 3) File group `mets:fileGrp`
+## 3) File group `mets:fileGrp`
 
-## 3.1 File Group `@USE` syntax
+### 3.1 File Group `@USE` syntax
 
 All `mets:fileGrp` MUST have a **unique** `USE` attribute that hints at the provenance of the files and must be a valid [`xsd:ID`](https://www.w3.org/TR/xmlschema11-2/#ID).
 
@@ -157,7 +157,7 @@ all-caps form, such as the name of the tool (`KRAKEN`) or the organisation
 `CIS` or the type of manipulation (`CROP`) or a combination of both starting
 with the type of manipulation (`BIN-KRAKEN`).
 
-### Examples
+#### Example
 
 `<mets:fileGrp USE>`                       | Type of use for OCR-D
 --                                         | --
@@ -180,24 +180,22 @@ with the type of manipulation (`BIN-KRAKEN`).
 `<mets:fileGrp USE="OCR-D-GT-SEG-WORD">`   | Word segmentation ground truth
 `<mets:fileGrp USE="OCR-D-GT-SEG-GLYPH">`  | Glyph segmentation ground truth
 
-## 3.2 File Group `@USE="FULLDOWNLOAD_..."`
-
-#### Fulldownload
+### 3.2 File Group `@USE="FULLDOWNLOAD_..."`
 
 For `mets:file` entries representative of the publication **as a whole**, the `ID` attribute MUST have  prefix `FULLDOWNLOAD_`, followed by the file format (`TEI`, `ALTO`, `hOCR`, `HTML`, `TXT`, `COCO`, `PDF`).
 
 These entries SHOULD be referenced in the [structMap](#ocr-d-structmap) under `/mets:mets/mets:structMap[@TYPE="PHYSICAL"]/mets:fptr`.
 
-##### Examples
+#### Example
 `<mets:file ID>` | ID of the file for OCR-D
 --               | --
 `<mets:file ID="FULLDOWNLOAD_TEI"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format.
 `<mets:file ID="FULLDOWNLOAD_TEI_01"  MIMETYPE="application/pdf">`            | The digitised publication or book in TEI format. Version one.
 `<mets:file ID="FULLDOWNLOAD_TEI_02"  MIMETYPE="application/tei+xml">`            | The digitised publication or book in TEI format, a second Version.
 
-# 4) File `mets:file` 
+## 4) File `mets:file` 
 
-## File ID syntax
+### 4.1 File ID syntax
 
 Each `mets:file` must have an `ID` attribute. The `ID` attribute of a `mets:file` SHOULD be the `USE` of the containing `mets:fileGrp` combined with a 4-zero-padded number.
 The `ID` MUST be unique inside the METS file.
@@ -206,7 +204,8 @@ The `ID` MUST be unique inside the METS file.
 FILEID := ID + "_" + [0-9]{4}
 ID := FILEGRP + (".IMG")?
 ```
-### Examples
+
+#### Example
 
 `<mets:file ID>` | ID of the file for OCR-D
 --               | --
@@ -216,9 +215,9 @@ ID := FILEGRP + (".IMG")?
 `<mets:file ID="OCR-D-PRE-CROP_0001">`       | PAGE encapsulating the result from (binarization and) cropping
 `<mets:file ID="OCR-D-PRE-CROP.IMG_0001">`   | Cropped black-and-white image
 
-# 5) Grouping files by page `mets:structMap`
+## 5) Grouping files by page `mets:structMap`
 
-## 5.1 Grouping files by page
+### 5.1 Grouping files by page
 
 Every METS file MUST have exactly one physical map that contains a single
 `mets:div[@TYPE="physSequence"]` which in turn must contain a
@@ -228,7 +227,7 @@ These `mets:div[@TYPE="page"]` can contain an arbitrary number of `mets:fptr`
 pointers to `mets:file` elements to signify that all the files within a div are
 encodings of the same page.
 
-### Example
+#### Example
 
 ```xml
 <mets:fileGrp USE="OCR-D-IMG">
@@ -247,7 +246,7 @@ encodings of the same page.
 </mets:structMap>
 ```
 
-## 5.2 OCR-D `mets:structMap`
+### 5.2 OCR-D `mets:structMap`
 
 A METS may contain different `mets:structMap` entries, differentiated by their `TYPE` attribute (e.g. `LOGICAL`, `PHYSICAL, ...`). 
 * A `mets:structMap` with `TYPE="PHYSICAL"` is mandatory.
@@ -259,14 +258,11 @@ attributes in `structMap` | description
 `LABEL` | contains the recognized text of a structuring component, e.g. the title of a chapter
 `TYPE` | contains the type of a structuring component according to some standardized, controlled vocabulary (see [DFG-Viewer: structural data set](https://dfg-viewer.de/strukturdatenset/)), e.g. `chapter`
 
-# 6) Ranges of pages `mets:structLink`
-
-### `mets:structLink`
+## 6) Ranges of pages `mets:structLink`
 
 The `mets:structLink`describes the range of pages in part of document.
 
-
-### Example
+#### Example
 
 ```xml
 <mets:fileGrp USE="OCR-D-IMG">
@@ -327,5 +323,3 @@ The `mets:structLink`describes the range of pages in part of document.
 
 </mets:structLink>
 ```
-
-


### PR DESCRIPTION
This is meant as a replacement for/supersedes [154](https://github.com/OCR-D/spec/pull/154/files) and [155](https://github.com/OCR-D/spec/pull/155/files) since the changes and discussion there became a bit fragmented and difficult to review.

It integrates all additions from both PRs into a new `mets.md` with this structure:


> 1. Metadata
  1.1 Unique ID for the document processed
  1.2 Always use URL or relative filenames
  1.3 Recording processing information in METS
> 2. Images
  2.1 If in PAGE then in METS
  2.2 Pixel density of images must be explicit and high enough
  2.3 No multi-page images
  2.4 Images and coordinates
> 3. File group `mets:fileGrp`
  3.1 File Group `@USE` syntax
  3.2 File Group `@USE="FULLDOWNLOAD_..."`
> 4. File `mets:file`
  4.1 File ID syntax
  4.2 `@MIMETYPE` syntax
> 5. Grouping files by page `mets:structMap`
  5.1 Grouping files by page
  5.2 OCR-D `mets:structMap`
> 6. Ranges of pages `mets:structLink`


I hope I have not missed anything and that this will allow us to soon integrate these changes. 