### PR TITLE
webapi-spec: content of put/post for workspaces

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -165,7 +165,7 @@ paths:
           description: Return Log
           content:
             'text/plain': {}
-        '404': 
+        '404':
           description: 'ProcessorJob not found'
 
   '/workflow':
@@ -282,7 +282,8 @@ paths:
       requestBody:
         description: OCRD-ZIP of the new workspace
         content:
-          'application/vnd.ocrd+zip': {}
+          'application/vnd.ocrd+zip':
+            schema: {$ref: '#/components/schemas/WorkspaceRequest'}
         required: true
       responses:
         '201':
@@ -306,13 +307,13 @@ paths:
       requestBody:
         description: OCRD-ZIP of the updated workspace
         content:
-          multipart/form-data:
+          'application/vnd.ocrd+zip':
             schema: {$ref: '#/components/schemas/WorkspaceRequest'}
         required: true
       responses:
         '200':
           description: Workspace replaced or created
-          content: 
+          content:
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
         '400':
           description: Workspace invalid
@@ -391,8 +392,6 @@ components:
     WorkspaceRequest:
       type: object
       properties:
-        json:
-          $ref: '#/components/schemas/Workspace'
         workspace:
           type: string
           format: binary

--- a/openapi.yml
+++ b/openapi.yml
@@ -283,7 +283,9 @@ paths:
         description: OCRD-ZIP of the new workspace
         content:
           'application/vnd.ocrd+zip':
-            schema: {$ref: '#/components/schemas/WorkspaceRequest'}
+            schema:
+              type: string
+              format: binary
         required: true
       responses:
         '201':
@@ -308,7 +310,9 @@ paths:
         description: OCRD-ZIP of the updated workspace
         content:
           'application/vnd.ocrd+zip':
-            schema: {$ref: '#/components/schemas/WorkspaceRequest'}
+            schema:
+              type: string
+              format: binary
         required: true
       responses:
         '200':
@@ -389,12 +393,6 @@ components:
     Workspace:
       allOf:
         - {$ref: '#/components/schemas/Resource'}
-    WorkspaceRequest:
-      type: object
-      properties:
-        workspace:
-          type: string
-          format: binary
     Job:
       allOf:
         - {$ref: '#/components/schemas/Resource'}


### PR DESCRIPTION
In my opinion the content/body for post and put a workspace have to be the same. But I'm not 100 % sure how to define them. I read this https://swagger.io/docs/specification/describing-request-body/file-upload/ and that: https://stackoverflow.com/questions/14455408/how-to-post-files-in-swagger-openapi.
I want to use `WorkspaceRequest` defined in component.schema, but I think the json-part should be left out. So this PR is what I came up with.