### PR TITLE
openapi: support content-negotiation via Accept for /workspace

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -314,6 +314,7 @@ paths:
           description: Workspace replaced or created
           content: 
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
+            application/vnd.ocrd+zip: {}
         '400':
           description: Workspace invalid
     get:
@@ -330,6 +331,7 @@ paths:
           description: Workspace found
           content:
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
+            application/vnd.ocrd+zip: {}
         '404':
           description: Workspace not found
           content: {}
@@ -350,6 +352,7 @@ paths:
           description: Workspace deleted
           content:
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
+            application/vnd.ocrd+zip: {}
         '404':
           description: Workspace not found
           content: {}

--- a/openapi.yml
+++ b/openapi.yml
@@ -314,7 +314,6 @@ paths:
           description: Workspace replaced or created
           content: 
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
-            application/vnd.ocrd+zip: {}
         '400':
           description: Workspace invalid
     get:
@@ -328,7 +327,7 @@ paths:
           required: true
       responses:
         '200':
-          description: Workspace found
+          description: Return workspace or OCRD-ZIP
           content:
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
             application/vnd.ocrd+zip: {}
@@ -352,7 +351,6 @@ paths:
           description: Workspace deleted
           content:
             application/json: {schema: {$ref: '#/components/schemas/Workspace'}}
-            application/vnd.ocrd+zip: {}
         '404':
           description: Workspace not found
           content: {}


### PR DESCRIPTION
cf. https://github.com/OCR-D/zenhub/issues/103

Depending on the `Accept` HTTP header, return either the JSON description of the workspace or the workspace itself.