### PR TITLE
openapi: Add requestBody to runWorkflow

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -454,7 +454,10 @@ components:
       required: ['workspace_id']
       properties:
         workspace_id: {type: string}
-        parameters:
+        workflow_parameters:
+          description: >-
+            Possibility to add additional parameters for the workflow. The parameters that can/must
+            be specified here depend on the respective implementation of the workflow.
           type: object
           default: {}
     WorkflowJob:

--- a/openapi.yml
+++ b/openapi.yml
@@ -231,6 +231,11 @@ paths:
           description: ID of the Workflow
           schema: {type: string}
           required: true
+      requestBody:
+        description: Execute this Workflow
+        content:
+          application/json: {schema: {$ref: '#/components/schemas/WorkflowArgs'}}
+        required: true
       responses:
         '200':
           description: Return WorkflowJob
@@ -443,6 +448,15 @@ components:
     Workflow:
       allOf:
         - {$ref: '#/components/schemas/Resource'}
+    WorkflowArgs:
+      description: The arguments needed to run the Workflow
+      type: object
+      required: ['workspace_id']
+      properties:
+        workspace_id: {type: string}
+        parameters:
+          type: object
+          default: {}
     WorkflowJob:
       allOf:
         - {$ref: '#/components/schemas/Job'}


### PR DESCRIPTION
Currently, I think, we only need the workspace_id (and the workflow_id provided in the path) to run a workflow. I think this is always required for other implementers as well. Please correct me if I am wrong. But I think that it is likely, that we or other implementers may encounter another parameter needed, like the starting file-grp for example. Because of that, I decided to add the `parameters` section like in processorArgs. I think this gives more flexibility to the implementers. Because I am not too sure about that please don't hesitate to comment if you have another opinion on that.