### PR TITLE
change content-type GET workflow/{workflow-id} according to POST /workflow

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -219,7 +219,7 @@ paths:
           description: Return Workflow
           content:
             application/json: {schema: {$ref: '#/components/schemas/Workflow'}}
-            application/vnd.ocrd+zip: {}
+            'text/vnd.ocrd.workflow': {}
         '404':
           description: 'Workflow not available'
     post:


### PR DESCRIPTION
In `POST /workflow` (upload a workflow-script) the content-type is `text/vnd.ocrd.workflow`. Because of that I think the content type to get back a workflow must be the same and not `application/vnd.ocrd+zip`.