### PR TITLE
Makefile to build JSON from yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+json: \
+	bagit-profile.json \
+	ocrd_tool.schema.json \
+	openapi.json
+
+deps:
+	pip install yaml click
+
+%.json: %.yml
+	python3 scripts/yaml-to-json.py $< $@

--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ See [https://ocr-d.de/en/spec/](https://ocr-d.de/en/spec/).
 ## Translating the spec
 
 The specification is in English. To add a german translation of a file, replace the `.md` suffix with `.de.md`.
+
+## Building JSON files
+
+`.json` files are built from the easier-to-edit `.yml` files.
+
+To regenerate the `.json` files after editing `.yml` files, run
+
+```sh
+make json
+```
+
+This requires python3 with the `click` and `yaml` libraries. To install the libraries run
+
+```sh
+make deps
+```

--- a/scripts/yaml-to-json.py
+++ b/scripts/yaml-to-json.py
@@ -1,0 +1,20 @@
+#!env python3
+
+from yaml import safe_load
+from json import dumps
+from click import command, argument, option
+
+@command()
+@option('--indent', default=2, type=int)
+@argument('src')
+@argument('dst')
+def cli(src, dst, indent):
+    kwargs = {}
+    if indent > 0:
+        kwargs['indent'] = indent
+    with open(src, 'r', encoding='utf-8') as f_in, open(dst, 'w', encoding='utf-8') as f_out:
+        ret = safe_load(f_in)
+        f_out.write(dumps(ret, **kwargs))
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This allows rebuilding the JSON files from their YAML sources from within the spec repository.

@mweidling @paulpestov I prefer YAML for editing because there is less noise and no issues about trailing commas etc. But of course the actual exchange format for ocrd-tool (and later ocrd-eval) will be serialized as JSON.